### PR TITLE
Term (title attribute) does not work for [definition] shortcode

### DIFF
--- a/includes/shortcodes/shortcode-definition.php
+++ b/includes/shortcodes/shortcode-definition.php
@@ -24,7 +24,7 @@ if ( ! function_exists( 'cpo_shortcode_definition' ) ) {
 		}
 
 		$output  = '<dl class="ctsc-definition ' . esc_attr( $attributes['class'] ) . '"' . $element_id . '>';
-		$output .= '<dt class="ctsc-definition-term">' . esc_html( $title ) . '</dt>';
+		$output .= '<dt class="ctsc-definition-term">' . esc_html( $attributes['title'] ) . '</dt>';
 		$output .= '<dd class="ctsc-definition-description">' . wp_kses_post( $content ) . '</dd>';
 		$output .= '</dl>';
 


### PR DESCRIPTION
Fixed display of title for definition shortcode